### PR TITLE
Add to cart

### DIFF
--- a/client/components/Cart.js
+++ b/client/components/Cart.js
@@ -11,26 +11,39 @@ import {
 class Cart extends Component {
   constructor(props) {
     super(props);
-    this.state = this.props.cartProds || [];
-    // this.handleChange = this.handleChange.bind(this);
+    this.handleChange = this.handleChange.bind(this);
+    this.state = {}
+    this.componentWillReceiveProps = this.componentWillReceiveProps.bind(this);
+
   }
 
   componentDidMount() {
     this.props.loadCartData();
   }
 
-  // handleChange(e, index, newQuantity) {
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.cartProds.length) {
+      let test = nextProps.cartProds.reduce((prev, curr) => {
+        prev[curr.id] = curr.cartQuantity;
+        return prev;
+      },{})
+      this.setState(test);
+    }
+  }
 
-  //   //we have an array of objects
-  //   //want to change the cartQuantity at that index to be the updated quantity
-  // }
+  handleChange(e) {
+    let key = e.target.name;
+    let val = e.target.value;
+    this.props.updateCartQuant({changes: {[key]: val}})
+
+  }
 
   render() {
+
     let cart = this.props.cartProds;
     let cartTotal = this.props.cartTotal;
 
-    const createInvDD = (product, index) => {
-      console.log(product.inventory)
+    const createInvDD = (product) => {
       let inventoryArr = [];
       for (let i = 1; i <= product.inventory; i++) {
         inventoryArr.push(
@@ -42,7 +55,9 @@ class Cart extends Component {
         return (
           <select
             className="form-control"
-
+            name={product.id}
+            value={this.state[product.id]}
+            onChange={this.handleChange}
           >
             {inventoryArr}
           </select>
@@ -63,6 +78,7 @@ class Cart extends Component {
     }
 
     return (
+
       <div>
         <h2>MY CART</h2>
         <table id="cart-table">
@@ -74,7 +90,7 @@ class Cart extends Component {
               <td>Quantity</td>
               <td>Remove</td>
             </tr>
-            {cart.map((product, index) => {
+            {cart.map((product) => {
               return (
                 <tr key={product.id}>
                   <td>
@@ -84,7 +100,7 @@ class Cart extends Component {
                     <Link to={`/products/${product.id}`}>{product.name}</Link>
                   </td>
                   <td>${product.price}</td>
-                  <td>{createInvDD(product, index)}</td>
+                  <td>{createInvDD(product)}</td>
                   <td>
                     <button
                       onClick={() => this.props.removeFromCart({ product })}
@@ -101,12 +117,6 @@ class Cart extends Component {
           <span>TOTAL: ${cartTotal}</span>
         </div>
         <div id="cart-btn-div">
-          <button
-            className="btn btn-secondary"
-            onClick={() => this.props.updateCartQuant(this.state.cart)}
-          >
-            UPDATE CART
-          </button>
           <Link to="/checkout">
             <button className="btn btn-primary">CHECKOUT</button>
           </Link>
@@ -131,8 +141,8 @@ const mapDispatch = (dispatch, ownProps) => {
     removeFromCart(product) {
       dispatch(removeItemFromCart(product));
     },
-    updateCartQuant(cart) {
-      dispatch(updateCartQuantitiesOnServer(cart));
+    updateCartQuant(changes) {
+      dispatch(updateCartQuantitiesOnServer(changes));
     }
   };
 };

--- a/client/components/SingleProduct.js
+++ b/client/components/SingleProduct.js
@@ -1,7 +1,10 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { Link } from "react-router-dom";
-import { fetchProduct, updateCartOnServer } from "../store/index";
+import {
+  fetchProduct,
+  updateCartOnServer
+} from "../store/index";
 
 /**
  * COMPONENT
@@ -36,6 +39,59 @@ class SingleProduct extends Component {
       );
     }
 
+    let cartProds = this.props.cartProds;
+    let isInCart = cartProds.find(item => {
+      return item.id === product.id;
+    });
+
+    let cartForm;
+    if (isInCart) {
+      cartForm = (
+        <div>
+        <p>Pssst, I'm already in your cart.</p>
+        <Link to="/cart">
+          {}
+          <button type="submit" className="btn btn-primary">
+            SEE MY CART
+          </button>
+        </Link>
+        </div>
+      );
+    } else {
+      cartForm = (
+        <form className="form order-form">
+          <div className="form-group">
+            <label htmlFor="quantity">Quantity:</label>
+            <select
+              disabled={isInCart}
+              className="form-control"
+              id="quantityI"
+              name="quantity"
+              onChange={this.handleChange}
+              value={this.state.quantity}
+            >
+              {inventoryArr}
+            </select>
+          </div>
+          <Link to="/cart">
+            {}
+            <button
+              type="submit"
+              className="btn btn-primary"
+              onClick={evt =>
+                this.props.handleAddToCart(evt, {
+                  productId: product.id,
+                  quantity: +this.state.quantity
+                })
+              }
+            >
+              ADD TO CART
+            </button>
+          </Link>
+        </form>
+      );
+    }
+
     return (
       <div>
         <div>
@@ -48,29 +104,8 @@ class SingleProduct extends Component {
             <li>${product.price}</li>
           </ul>
         </div>
-        <form
-          className="form order-form"
-        >
-          <div className="form-group">
-            <label htmlFor="quantity">Quantity:</label>
-            <select
-              className="form-control"
-              id="quantityI"
-              name="quantity"
-              onChange={this.handleChange}
-              value={this.state.quantity}
-            >
-              {inventoryArr}
-            </select>
-          </div>
-            <Link to="/cart">
-            <button type="submit" className="btn btn-primary" onClick={evt => this.props.handleAddToCart(evt, {productId: product.id, quantity: +this.state.quantity})}>
-              ADD TO CART
-            </button>
-            </Link>
-          </form>
-        </div>
-
+        {cartForm}
+      </div>
     );
   }
 }
@@ -80,7 +115,8 @@ class SingleProduct extends Component {
  */
 const mapState = state => {
   return {
-    productData: state.product.currentProduct
+    productData: state.product.currentProduct,
+    cartProds: state.cart.cartProds
   };
 };
 
@@ -90,9 +126,8 @@ const mapDispatch = (dispatch, ownProps) => {
       const productThunk = fetchProduct(ownProps.match.params.productId);
       dispatch(productThunk);
     },
-    handleAddToCart(evt,prodInfo) {
-      // evt.preventDefault();
-      dispatch(updateCartOnServer(prodInfo))
+    handleAddToCart(evt, prodInfo) {
+      dispatch(updateCartOnServer(prodInfo));
     }
   };
 };

--- a/client/components/SingleProduct.js
+++ b/client/components/SingleProduct.js
@@ -48,7 +48,7 @@ class SingleProduct extends Component {
     if (isInCart) {
       cartForm = (
         <div>
-        <p>Pssst, I'm already in your cart.</p>
+        <p>Pssst, already in your cart.</p>
         <Link to="/cart">
           {}
           <button type="submit" className="btn btn-primary">

--- a/client/store/cart.js
+++ b/client/store/cart.js
@@ -34,6 +34,7 @@ const deleteCart = () => {
 
 //THUNK CREATORS
 
+//get cart info
 export const fetchCartFromServer = () => {
   return function thunk(dispatch) {
     return axios.get('/api/cart')
@@ -45,6 +46,7 @@ export const fetchCartFromServer = () => {
   }
 }
 
+//add an item to cart
 export const updateCartOnServer = (product) => {
   return function thunk(dispatch) {
     return axios.post('/api/cart', product)
@@ -57,9 +59,10 @@ export const updateCartOnServer = (product) => {
   }
 }
 
-export const updateCartQuantitiesOnServer = (cart) => {
+//update the cart - from cart page
+export const updateCartQuantitiesOnServer = (changes) => {
   return function thunk(dispatch) {
-    return axios.put('/api/cart', cart)
+    return axios.put('/api/cart', changes)
     .then(res => res.data)
     .then(updatedCart => {
       dispatch(updateCart(updatedCart))
@@ -68,6 +71,7 @@ export const updateCartQuantitiesOnServer = (cart) => {
   }
 }
 
+//remove item from cart - from cart page
 export const removeItemFromCart = (product) => {
   return function thunk(dispatch) {
     return axios.put('/api/cart/remove', product)
@@ -79,6 +83,7 @@ export const removeItemFromCart = (product) => {
   }
 }
 
+//delete cart - when it turns into an order
 export const deleteCartOnServer = () => {
   return function thunk(dispatch) {
     return axios.delete('/api/cart')

--- a/server/api/cart.js
+++ b/server/api/cart.js
@@ -28,8 +28,16 @@ router.post('/', (req, res, next) => {
 
 //to edit an item in the cart
 //will happen from view my cart page
+
+//req.body {changes: {}}
 router.put('/', (req, res, next) => {
-  req.session.cart = req.body.cart
+  let changes = req.body.changes;
+  req.session.cart = req.session.cart.map(item => {
+    if (changes[item.id]) {
+      return Object.assign(item, {cartQuantity: changes[item.id]});
+    }
+    else return item;
+  })
   .filter(cartProduct => cartProduct.cartQuantity > 0);
   res.json(req.session.cart);
 


### PR DESCRIPTION
Cart updates are all set:
From single product page: User can add to cart, up to whatever quantity is in stock. This option is removed if the item is already in their cart. Instead of add to cart, they'll see 'this item is already in your cart' and then a button to go to their cart. This should be simpler than having to add the quantities together if an item is already in the cart. Can change this logic if it's weird to anyone.
From cart page: User can edit cart quantities and see automatically updated $ total. User can remove an item. User can go to checkout.